### PR TITLE
fix Travis badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Anima Engine. The quirky game engine.
 [![Gitter](https://badges.gitter.im/anima-engine/anima-engine.svg)](https://gitter.im/anima-engine/anima-engine?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
-[![Build Status]
-(https://travis-ci.org/anima-engine/anima-engine.svg?branch=master)]
-(https://travis-ci.org/anima-engine/anima-engine)
+[![Build Status](https://travis-ci.org/anima-engine/anima-engine.svg?branch=master)](https://travis-ci.org/anima-engine/anima-engine)
 
 # Roadmap
 


### PR DESCRIPTION
The Travis badge was incorrectly formatted in the README, so I deleted the problematic newlines.  The badge appears to function now.

Fixes #15